### PR TITLE
멀티 모듈 환경에서 DB 연동

### DIFF
--- a/module-api/src/main/java/dev/be/moduleapi/ModuleApiApplication.java
+++ b/module-api/src/main/java/dev/be/moduleapi/ModuleApiApplication.java
@@ -2,10 +2,14 @@ package dev.be.moduleapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(
         scanBasePackages = {"dev.be.moduleapi", "dev.be.modulecommon"}
 )
+@EntityScan("dev.be.modulecommon.domain")
+@EnableJpaRepositories(basePackages =  "dev.be.modulecommon.repositories")
 public class ModuleApiApplication {
 
     public static void main(String[] args) {

--- a/module-api/src/main/java/dev/be/moduleapi/service/DemoService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/service/DemoService.java
@@ -1,7 +1,9 @@
 package dev.be.moduleapi.service;
 
 import dev.be.moduleapi.exception.CustomException;
+import dev.be.modulecommon.domain.Member;
 import dev.be.modulecommon.enums.CodeEnum;
+import dev.be.modulecommon.repositories.MemberRepository;
 import dev.be.modulecommon.service.CommonDemoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,14 +13,18 @@ import org.springframework.stereotype.Service;
 public class DemoService {
 
     private final CommonDemoService commonDemoService;
+    private final MemberRepository memberRepository;
 
     public String save() {
-        System.out.println(CodeEnum.SUCCESS.getCode());
-        System.out.println(commonDemoService.commonService());
+        memberRepository.save(Member.builder()
+                .name(Thread.currentThread().getName())
+                .build());
         return "save";
     }
 
     public String find() {
+        int size = memberRepository.findAll().size();
+        System.out.println("DB size : " + size);
         return "find";
     }
 

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.2'
 	id 'io.spring.dependency-management' version '1.1.3'
+	id 'java-library'
 }
 
 group = 'dev.be'
@@ -26,6 +27,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	api 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'mysql:mysql-connector-java'
 }
 
 tasks.named('test') {

--- a/module-common/src/main/java/dev/be/modulecommon/domain/Member.java
+++ b/module-common/src/main/java/dev/be/modulecommon/domain/Member.java
@@ -1,0 +1,23 @@
+package dev.be.modulecommon.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+}

--- a/module-common/src/main/java/dev/be/modulecommon/repositories/MemberRepository.java
+++ b/module-common/src/main/java/dev/be/modulecommon/repositories/MemberRepository.java
@@ -1,0 +1,7 @@
+package dev.be.modulecommon.repositories;
+
+import dev.be.modulecommon.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}


### PR DESCRIPTION
간단한 멤버 엔티티를 만들어 DB 연동 테스트를 해보았다.

`@EntityScan("dev.be.modulecommon.domain")`
`@EnableJpaRepositories(basePackages =  "dev.be.modulecommon.repositories")`
를 `ModuleApiApplication`에 붙여줘야 인식을 하고 실행된다.

즉 다른 모듈의 도메인과 리포지토리를 사용하려면 위의 어노테이션을 사용해야 한다.