### PR TITLE
멀티 모듈 환경에서 배포

### DIFF
--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -35,3 +35,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+tasks.bootJar { enabled = false} //xxx.jar 라는 형식으로 만들어짐 , common module은 참조로 쓰이는 모듈이기 때문에 jar가 만들어질 필요가 없기 때문에 false로 설정
+tasks.jar { enabled = true } //xxx-plain.jar 라는 형식으로 만들어짐, 디펜던시를 가지지 않음, 서버를 실행시킬 수 없음, 디폴트가 트루라 명시를 안 해줘도 되지만 걍 해줌


### PR DESCRIPTION
1. **module-common**은 참조를 위한 모듈이기 때문에,
`tasks.bootJar { enabled = false}` *//xxx.jar 라는 형식으로 만들어짐 , common module은 참조로 쓰이는 모듈이기 때문에 jar가 만들어질 필요가 없기 때문에 false로 설정*
`tasks.jar { enabled = true }` *//xxx-plain.jar 라는 형식으로 만들어짐, 디펜던시를 가지지 않음, 서버를 실행시킬 수 없음, 디폴트가 트루라 명시를 안 해줘도 되지만 걍 해줌*
이런 식으로 build.gradle에 작성한다.

2. 터미널에서 아래의 명령어를 입력한다.
`./gradlew clean :module-api:buildNeeded —stacktrace —info —refresh-dependencies -x test`

3. 그럼 **module-api**에서 build 라는 폴더가 생기는데 터미널에서 build/libs 폴더의 위치로 가서
`java -jar module-api-0.0.1-SNAPSHOT.jar` 명령어를 입력한다.

4. 그러면 배포가 완료되고, 터미널에서 curl 명령어를 사용해 localhost를 호출하면 정상적으로 동작하는 것을 알 수 있다.